### PR TITLE
Add OpenClaw gateway hook for live telemetry

### DIFF
--- a/examples/openclaw-hook/HOOK.md
+++ b/examples/openclaw-hook/HOOK.md
@@ -54,13 +54,19 @@ Then enable in `openclaw.json`:
 
 Restart the gateway to load the hook.
 
+## How it works
+
+The hook correlates `message:received` and `message:sent` events by conversation ID to compute **real round-trip duration** — the time from when a message arrives to when the reply is delivered. Each conversation turn becomes a trace with nested spans (conversation + delivery), giving you a waterfall view in the dashboard.
+
+Events that can't be correlated (e.g. outbound-only announcements) still produce traces with zero duration.
+
 ## Configuration
 
 Set the following environment variables (via `hooks.internal.entries.agentwatch.env` in `openclaw.json` or container env):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AGENTWATCH_URL` | `http://172.17.0.1:8470` | AgentWatch server URL (use Docker gateway IP from container) |
+| `AGENTWATCH_URL` | `http://172.17.0.1:8470` | AgentWatch server URL (see note below) |
 | `AGENTWATCH_TOKEN` | *(none)* | Optional auth token |
 | `AGENTWATCH_AGENT_NAME` | `openclaw-gateway` | Agent name in dashboard |
 
@@ -72,3 +78,13 @@ agentwatch serve --host 0.0.0.0 --port 8470
 ```
 
 Then open `http://localhost:8470` to see your OpenClaw telemetry.
+
+## Network note
+
+The default `AGENTWATCH_URL` uses `172.17.0.1` — the Docker bridge gateway IP that lets the container reach the host. This works when OpenClaw runs in Docker and AgentWatch runs on the host.
+
+| Setup | URL to use |
+|-------|-----------|
+| OpenClaw in Docker, AgentWatch on host | `http://172.17.0.1:8470` (default) |
+| Both on the same host (no Docker) | `http://localhost:8470` |
+| AgentWatch on a different machine | `http://<agentwatch-ip>:8470` |

--- a/examples/openclaw-hook/handler.ts
+++ b/examples/openclaw-hook/handler.ts
@@ -23,6 +23,11 @@ const AGENT_NAME = process.env.AGENTWATCH_AGENT_NAME || "openclaw-gateway";
 
 const MAX_CONTENT = 200;
 
+// Track open conversations: conversationId → receive timestamp (for duration)
+const pendingConversations = new Map<string, number>();
+// Auto-expire stale entries after 10 minutes
+const PENDING_TTL_MS = 10 * 60 * 1000;
+
 // ── Helpers ────────────────────────────────────────────────────────────
 
 function uuid(): string {
@@ -196,14 +201,24 @@ const handler = async (event: any) => {
         context?.metadata?.senderName || context?.from || "unknown";
       const channel = context?.channelId || "unknown";
       const isGroup = !!context?.isGroup;
+      const convId = context?.conversationId as string | undefined;
 
-      sendTrace("msg:received:" + channel, "completed", 1, {
+      // Track receive time so we can compute round-trip on the sent event
+      if (convId) {
+        pendingConversations.set(convId, Date.now());
+        // Expire stale entries
+        for (const [k, ts] of pendingConversations) {
+          if (Date.now() - ts > PENDING_TTL_MS) pendingConversations.delete(k);
+        }
+      }
+
+      sendLog("info", `Message from ${from} (${channel})`, {
         direction: "inbound",
         channel,
         from,
         isGroup,
         content: truncate(content, MAX_CONTENT),
-        conversationId: context?.conversationId,
+        conversationId: convId,
       });
 
       sendMetric("messages_received", 1, { channel });
@@ -218,27 +233,85 @@ const handler = async (event: any) => {
       const to = context?.to || "unknown";
       const channel = context?.channelId || "unknown";
       const success = context?.success !== false;
+      const convId = context?.conversationId as string | undefined;
 
-      sendTrace(
-        "msg:sent:" + channel,
-        success ? "completed" : "failed",
-        1,
-        {
-          direction: "outbound",
-          channel,
+      // Compute real round-trip duration if we have the receive timestamp
+      let durationMs = 0;
+      let startedAt: string;
+      const endedAt = now();
+      const receiveTs = convId ? pendingConversations.get(convId) : undefined;
+
+      if (receiveTs) {
+        durationMs = Date.now() - receiveTs;
+        startedAt = new Date(receiveTs).toISOString();
+        pendingConversations.delete(convId!);
+      } else {
+        startedAt = endedAt;
+      }
+
+      // Build a trace with receive + sent spans for the full round-trip
+      const traceId = uuid();
+      const spans: Record<string, unknown>[] = [];
+
+      if (receiveTs) {
+        // Span covering the full conversation turn
+        spans.push({
+          id: uuid(),
+          trace_id: traceId,
+          name: "conversation:" + channel,
+          status: success ? "completed" : "failed",
+          started_at: startedAt,
+          ended_at: endedAt,
+          duration_ms: durationMs,
+          metadata: { channel, conversationId: convId },
+          events: [],
+        });
+      }
+
+      // Delivery span
+      spans.push({
+        id: uuid(),
+        trace_id: traceId,
+        parent_id: spans.length > 0 ? (spans[0] as any).id : undefined,
+        name: "deliver:" + channel,
+        status: success ? "completed" : "failed",
+        started_at: endedAt,
+        ended_at: endedAt,
+        duration_ms: 0,
+        metadata: {
           to,
           success,
           error: context?.error,
-          isGroup: !!context?.isGroup,
           content: truncate(content, MAX_CONTENT),
-          conversationId: context?.conversationId,
-        }
-      );
+        },
+        events: [],
+      });
+
+      void post("traces", {
+        id: traceId,
+        agent_name: AGENT_NAME,
+        name: "conversation:" + channel,
+        status: success ? "completed" : "failed",
+        started_at: startedAt,
+        ended_at: endedAt,
+        duration_ms: durationMs,
+        metadata: {
+          channel,
+          to,
+          isGroup: !!context?.isGroup,
+          conversationId: convId,
+        },
+        spans,
+      });
 
       sendMetric("messages_sent", 1, {
         channel,
         success: String(success),
       });
+
+      if (durationMs > 0) {
+        sendMetric("response_time_ms", durationMs, { channel });
+      }
 
       if (!success && context?.error) {
         sendLog("error", "Message delivery failed: " + context.error, {


### PR DESCRIPTION
## Summary
- Adds a TypeScript hook that runs inside the OpenClaw gateway container and sends traces, logs, health checks, and metrics to AgentWatch via the HTTP ingestion API
- Fire-and-forget design — all POSTs are non-blocking so message processing latency is unaffected
- Configurable via env vars (`AGENTWATCH_URL`, `AGENTWATCH_TOKEN`, `AGENTWATCH_AGENT_NAME`)
- Filters heartbeat/noise messages, truncates content for storage efficiency
- Includes `HOOK.md` with install instructions and config reference

## What it tracks
| Event | AgentWatch type |
|-------|----------------|
| `gateway:startup` | health check + log |
| `message:received` | trace + metric |
| `message:sent` | trace + metric (+ error log on failure) |
| `command:new`, `command:reset` | trace + log |

## Test plan
- [x] Hook loads on gateway restart (verified: "Registered hook: agentwatch -> gateway:startup, message:received, message:sent, command:new, command:reset")
- [x] Startup health check ingested into AgentWatch
- [x] Startup log ingested into AgentWatch
- [ ] Send a WhatsApp message and verify inbound/outbound traces appear in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)